### PR TITLE
Add test for more than one Host header field

### DIFF
--- a/http_test.ts
+++ b/http_test.ts
@@ -130,6 +130,11 @@ const testCases: TestCase[] = [
         expectedStatus: [[400, 499]],
     },
     {
+        request: "GET / HTTP/1.1\r\nHost: example.com\r\nHost: example.org\r\n\r\n",
+        description: "Multiple Host headers",
+        expectedStatus: [[400, 499]],
+    },
+    {
         request: "GET / HTTP/1.1\r\nHost: example.com\r\nContent-Length: -123456789123456789123456789\r\n\r\n",
         description: "Overflowing negative Content-Length header",
         expectedStatus: [[400, 499]],


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3

> A server MUST respond with a 400 (Bad Request) status code to any
   HTTP/1.1 request message that lacks a Host header field and to any
   request message that contains more than one Host header field or a
   Host header field with an invalid field-value.